### PR TITLE
Add a yaml option "listed"

### DIFF
--- a/content/blog/2017-01-01-unlisted/index.html
+++ b/content/blog/2017-01-01-unlisted/index.html
@@ -1,0 +1,10 @@
+---
+state:      post
+title:      An Unlisted Post
+date:       2017-01-01 12:00:00 -08:00
+listed:     false
+---
+
+<p>
+This is an unlisted post.
+</p>

--- a/content/blog/2017-01-01-welcome/index.html
+++ b/content/blog/2017-01-01-welcome/index.html
@@ -18,3 +18,9 @@ This is an image.
 </p>
 
 <img src="example.jpg">
+
+<p>
+<a href="../2017-01-01-unlisted">
+This is a link to an unlisted post.
+</a>
+</p>

--- a/tools/generator.py
+++ b/tools/generator.py
@@ -184,6 +184,8 @@ def render_blog(folders, root, page):
     while count > 0 and len(folders) > 0:
         folder = folders.pop(0)
         item = load_post("content/blog/" + folder + "/index.html")
+        if "listed" in item and item["listed"] == "false":
+            continue
         if item and (item["state"] == "post" or environment != "production"):
             item["url"] = "blog/" + folder + "/"
             if "date" in item:
@@ -238,7 +240,7 @@ def render_feed(source, destination):
         "author": configuration["name"],
         "host": host,
         "url": url,
-        "items": [] 
+        "items": []
     }
     recent_found = False
     recent = datetime.datetime.now()


### PR DESCRIPTION
Enable users to set the post not listed in the blog page,
which can be used to:

- Arrange a series of posts into a single post,
  reducing the space costing of the blog page
- Link from the project cards to posts not listed in the blog page

Node and go versions are WIP.